### PR TITLE
Fix: truncate nanos from IAM condition time

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -1,0 +1,25 @@
+name: Build
+inputs:
+  version:
+    required: true
+    default: '1.0'
+  source-dir:
+    required: true
+    default: sources  
+runs:
+  using: "composite"
+  steps:
+    - name: Set up JDK 11
+      uses: actions/setup-java@v3
+      with:
+        java-version: '11'
+        distribution: 'temurin'
+        cache: 'maven'
+        
+    - name: Set version
+      run: mvn versions:set -DnewVersion=${{ inputs.version }}.${{ github.run_number }} --file ${{ inputs.source-dir }}/pom.xml
+      shell: bash
+      
+    - name: Build
+      run: mvn -P release -B package -Dmaven.test.skip=true --file ${{ inputs.source-dir }}/pom.xml
+      shell: bash

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "maven"
+    directory: "/sources"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "docker"
+    directory: "/sources"
+    schedule:
+      interval: "daily"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
       run: mvn -P release -B package -Dmaven.test.skip=true --file $SOURCE_DIR/pom.xml
 
     - name: 'Upload artifact'
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: jit-access.jar
         path: sources/target/*.jar

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
     - uses: actions/checkout@v3
     
     - name: Set up JDK 11
-      uses: actions/setup-java@v2
+      uses: actions/setup-java@v3
       with:
         java-version: '11'
         distribution: 'temurin'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,29 +26,15 @@ on:
     branches: [ master ]
   pull_request:
     branches: [ master ]
-
-env:
-  VERSION: '1.0'
-  SOURCE_DIR: sources
   
 jobs:
-  build:
+  ci:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    
-    - name: Set up JDK 11
-      uses: actions/setup-java@v3
-      with:
-        java-version: '11'
-        distribution: 'temurin'
-        cache: maven
-        
-    - name: Set version
-      run: mvn versions:set -DnewVersion=$VERSION.$GITHUB_RUN_NUMBER --file $SOURCE_DIR/pom.xml
-      
+
     - name: Build
-      run: mvn -P release -B package -Dmaven.test.skip=true --file $SOURCE_DIR/pom.xml
+      uses: ./.github/actions/build
 
     - name: 'Upload artifact'
       uses: actions/upload-artifact@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     
     - name: Set up JDK 11
       uses: actions/setup-java@v2

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,43 @@
+name: "CodeQL"
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+  schedule:
+    # Every Monday, 7:38 am UTC
+    - cron: '38 7 * * 1'
+
+jobs:
+  analyze:
+    name: Analyze
+    if: ${{ github.actor != 'dependabot[bot]' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 360
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [ 'java', 'javascript' ]
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v3
+
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v2
+      with:
+        languages: ${{ matrix.language }}
+
+    - name: Build
+      uses: ./.github/actions/build
+
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@v2
+      with:
+        category: "/language:${{ matrix.language }}"

--- a/sources/Dockerfile
+++ b/sources/Dockerfile
@@ -22,7 +22,7 @@
 #
 # Build stage.
 #
-FROM maven:3.8.7-eclipse-temurin-17-alpine AS build
+FROM maven:3.9.3-eclipse-temurin-17-alpine AS build
 WORKDIR /app
 
 # Copy local code to the container image.

--- a/sources/pom.xml
+++ b/sources/pom.xml
@@ -122,7 +122,7 @@
                 <path>
                   <groupId>com.google.errorprone</groupId>
                   <artifactId>error_prone_core</artifactId>
-                  <version>2.16</version>
+                  <version>2.20.0</version>
                 </path>
               </annotationProcessorPaths>
             </configuration>

--- a/sources/pom.xml
+++ b/sources/pom.xml
@@ -67,7 +67,7 @@
     <dependency>
       <groupId>com.google.apis</groupId>
       <artifactId>google-api-services-cloudasset</artifactId>
-      <version>v1-rev20230304-2.0.0</version>
+      <version>v1-rev20230609-2.0.0</version>
     </dependency>
     <dependency>
       <groupId>com.google.apis</groupId>

--- a/sources/pom.xml
+++ b/sources/pom.xml
@@ -112,7 +112,7 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-compiler-plugin</artifactId>
-            <version>3.8.0</version>
+            <version>3.11.0</version>
             <configuration>
               <compilerArgs>
                 <arg>-XDcompilePolicy=simple</arg>

--- a/sources/pom.xml
+++ b/sources/pom.xml
@@ -62,7 +62,7 @@
     <dependency>
       <groupId>com.google.apis</groupId>
       <artifactId>google-api-services-cloudresourcemanager</artifactId>
-      <version>v3-rev20230219-2.0.0</version>
+      <version>v3-rev20230507-2.0.0</version>
     </dependency>
     <dependency>
       <groupId>com.google.apis</groupId>

--- a/sources/pom.xml
+++ b/sources/pom.xml
@@ -95,7 +95,7 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
-      <version>5.2.0</version>
+      <version>5.4.0</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/sources/src/main/java/com/google/solutions/jitaccess/core/adapters/ResourceManagerAdapter.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/core/adapters/ResourceManagerAdapter.java
@@ -190,6 +190,21 @@ public class ResourceManagerAdapter {
     }
     catch (GoogleJsonResponseException e) {
       switch (e.getStatusCode()) {
+        case 400:
+          //
+          // One possible reason for an INVALID_ARGUMENT error is that we've tried
+          // to grant a role on a project that cannot be granted on a project at all.
+          // If that's the case, provide a more descriptive error message.
+          //
+          if (e.getDetails() != null &&
+              e.getDetails().getErrors() != null &&
+              e.getDetails().getErrors().size() > 0 &&
+              e.getDetails().getErrors().get(0).getMessage() != null &&
+              e.getDetails().getErrors().get(0).getMessage().contains("does not exist in the resource's hierarchy")) {
+            throw new AccessDeniedException(
+              String.format("The role %s cannot be granted on a project", binding.getRole()),
+              e);
+          }
         case 401:
           throw new NotAuthenticatedException("Not authenticated", e);
         case 403:

--- a/sources/src/main/java/com/google/solutions/jitaccess/core/services/RoleActivationService.java
+++ b/sources/src/main/java/com/google/solutions/jitaccess/core/services/RoleActivationService.java
@@ -39,6 +39,7 @@ import java.io.IOException;
 import java.security.SecureRandom;
 import java.time.Duration;
 import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.Base64;
 import java.util.EnumSet;
 import java.util.List;
@@ -170,7 +171,7 @@ public class RoleActivationService {
     // accumulating junk, and to prevent hitting the binding limit.
     //
 
-    var activationTime = Instant.now();
+    var activationTime = Instant.now().truncatedTo(ChronoUnit.SECONDS);;
     var expiryTime = activationTime.plus(activationTimeout);
     var bindingDescription = String.format(
       "Self-approved, justification: %s",
@@ -318,7 +319,7 @@ public class RoleActivationService {
     //
     // Issue an activation request.
     //
-    var startTime = Instant.now();
+    var startTime = Instant.now().truncatedTo(ChronoUnit.SECONDS);
     var endTime = startTime.plus(activationTimeout);
 
     return new ActivationRequest(

--- a/sources/src/test/java/com/google/solutions/jitaccess/core/adapters/TestResourceManagerAdapter.java
+++ b/sources/src/test/java/com/google/solutions/jitaccess/core/adapters/TestResourceManagerAdapter.java
@@ -81,6 +81,25 @@ public class TestResourceManagerAdapter {
   }
 
   @Test
+  public void whenRoleNotGrantableOnProject_ThenAddProjectIamBindingThrowsException() {
+    var adapter = new ResourceManagerAdapter(IntegrationTestEnvironment.APPLICATION_CREDENTIALS);
+
+    String condition =
+      IamTemporaryAccessConditions.createExpression(Instant.now(), Duration.ofMinutes(5));
+
+    assertThrows(
+      AccessDeniedException.class,
+      () ->
+        adapter.addProjectIamBinding(
+          IntegrationTestEnvironment.PROJECT_ID,
+          new Binding()
+            .setMembers(List.of("user:bob@example.com"))
+            .setRole("roles/billing.viewer"),
+          EnumSet.of(ResourceManagerAdapter.IamBindingOptions.NONE),
+          REQUEST_REASON));
+  }
+
+  @Test
   public void whenResourceIsProject_ThenAddIamProjectBindingSucceeds() throws Exception {
     var adapter = new ResourceManagerAdapter(IntegrationTestEnvironment.APPLICATION_CREDENTIALS);
 


### PR DESCRIPTION
The use of Instant type was creating a datetime value which included nano seconds. This was then carried through to the IAM conditional binding leading to conditions with a random number of trailing nano seconds as trailing zeros were truncated.

This made it hard to read the condition and a unnecessarily challenging to programmatically evaluate the IAM conditonal expression string in Python, when trying to determine to remove the binding for the cleanup.